### PR TITLE
Add MIT LICENSE file for open source compliance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Prayers-2004
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
This PR adds an MIT LICENSE file to the De-MAPP repository to properly define the terms under which the software can be used, modified, and distributed.

## Changes Made
- ✅ Added `LICENSE` file with MIT License terms
- ✅ Enables proper open source compliance
- ✅ Allows users to understand usage rights and restrictions

## Why This Change is Important
- Provides legal clarity for contributors and users
- Establishes proper open source licensing for the De-MAPP protocol
- Enables safe usage and contribution to the project
- Follows best practices for open source projects

## License Details
- **License Type**: MIT License
- **Copyright**: 2025 Prayers-2004
- **Permissions**: Commercial use, modification, distribution, private use
- **Limitations**: No warranty, no liability
- **Conditions**: Include copyright and license notice

## Testing
- [x] LICENSE file created successfully
- [x] File contains proper MIT license text
- [x] Copyright notice is correctly formatted

This addition will help the De-MAPP project maintain proper licensing standards and encourage community contributions.